### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/day14.rs
+++ b/src/day14.rs
@@ -211,7 +211,7 @@ pub fn solve_p2() -> i64 {
         }
 
         let fb = format!(
-            "[Frame {:4.} (+={})] \t\t [{}]{} \t\t\t {} \n{}",
+            "[Frame {:4} (+={})] \t\t [{}]{} \t\t\t {} \n{}",
             frame,
             skip_frames,
             if paused { "PAUSED" } else { "RUNNING" },


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.